### PR TITLE
Исправление Notice'а в панели управления, когда плагин отключен

### DIFF
--- a/elements/javascript.php
+++ b/elements/javascript.php
@@ -17,8 +17,8 @@ class JFormFieldJavascript extends JFormField {
 	public function getInput()	{
 
 		$isEnabled = JPluginHelper::isEnabled('system', 'jscssmanipulate');
-        $plugin = JPluginHelper::getPlugin('system', 'jscssmanipulate');
-        $plgParams = new JRegistry($plugin->params);
+		$plugin = JPluginHelper::getPlugin('system', 'jscssmanipulate');		
+		$plgParams = $isEnabled ? new JRegistry($plugin->params) : new JRegistry();
         $enableMinify = $plgParams->get('minify',0);
 
         JHtml::_('jquery.framework');

--- a/elements/javascript.php
+++ b/elements/javascript.php
@@ -16,6 +16,7 @@ class JFormFieldJavascript extends JFormField {
 
 	public function getInput()	{
 
+		$isEnabled = JPluginHelper::isEnabled('system', 'jscssmanipulate');
         $plugin = JPluginHelper::getPlugin('system', 'jscssmanipulate');
         $plgParams = new JRegistry($plugin->params);
         $enableMinify = $plgParams->get('minify',0);

--- a/elements/stylesheet.php
+++ b/elements/stylesheet.php
@@ -15,9 +15,10 @@ class JFormFieldStylesheet extends JFormField {
 
     public function getInput()	{
 
-        $plugin = JPluginHelper::getPlugin('system', 'jscssmanipulate');
-        $plgParams = new JRegistry($plugin->params);
-        $enableMinify = $plgParams->get('minify',0);
+		$isEnabled = JPluginHelper::isEnabled('system', 'jscssmanipulate');
+		$plugin = JPluginHelper::getPlugin('system', 'jscssmanipulate');		
+		$plgParams = $isEnabled ? new JRegistry($plugin->params) : new JRegistry();
+		$enableMinify = $plgParams->get('minify',0);
 
         JHtml::_('jquery.framework');
 	    JHtml::_('jquery.ui', array('core', 'sortable'));


### PR DESCRIPTION
Когда плагин отключен, панель управления пытается получить параметры плагина
`
$plugin = JPluginHelper::getPlugin('system', 'jscssmanipulate');
$plgParams = new JRegistry($plugin->params);
`
Поскольку плагин отключен, то в переменную `$plugin` пустой массив, а на экран выводится сообщение

> **Notice:** Trying to get property of non-object in \plugins\system\jscssmanipulate\elements\javascript.php on line 21

Если добавить проверку, включен ли плагин, и, когда он отключен, не обращаться к свойству `params` - сообщение исчезает

